### PR TITLE
Backend performance tests under engagement reporter

### DIFF
--- a/api/v1/test.py
+++ b/api/v1/test.py
@@ -3,6 +3,7 @@ from typing import Union
 
 from flask import request
 from flask_restful import Resource
+from pylon.core.tools import log
 
 from ...models.api_tests import PerformanceApiTest
 from ...models.pd.test_parameters import PerformanceTestParam, PerformanceTestParams
@@ -90,6 +91,9 @@ class API(Resource):
         """ Run test with possible overridden params """
         config_only_flag = request.json.pop('type', False)
         execution_flag = request.json.pop('execution', True)
+        engagement_id = request.json.get('integrations', {}).get('reporters', {})\
+            .get('reporter_engagement', {}).get('id')
+
         purpose = 'run'
         if 'params' in request.json:
             purpose = 'control_tower'
@@ -131,5 +135,5 @@ class API(Resource):
                        'config': run_test(test, config_only=True, execution=execution_flag),
                        'api_json': test.api_json(),
                    }, 200
-        resp = run_test(test, config_only=config_only_flag, execution=execution_flag)
+        resp = run_test(test, config_only=config_only_flag, execution=execution_flag, engagement_id=engagement_id)
         return resp, resp.get('code', 200)

--- a/api/v1/tests.py
+++ b/api/v1/tests.py
@@ -75,6 +75,10 @@ class API(Resource):
         """
         run_test_ = request.json.pop('run_test', False)
         compile_tests_flag = request.json.pop('compile_tests', False)
+        engagement_id = request.json.get('integrations', {}).get('reporters', {})\
+            .get('reporter_engagement', {}).get('id')
+
+
         test_data, errors = parse_test_data(
             project_id=project_id,
             request_data=request.json,
@@ -118,6 +122,6 @@ class API(Resource):
         test.handle_change_schedules(schedules)
 
         if run_test_:
-            resp = run_test(test)
+            resp = run_test(test, engagement_id=engagement_id)
             return resp, resp.get('code', 200)
         return test.api_json(), 200

--- a/models/api_reports.py
+++ b/models/api_reports.py
@@ -61,6 +61,9 @@ class APIReport(db_tools.AbstractBaseMixin, db.Base):
         }
     )
     test_config = Column(JSON, nullable=False, unique=False)
+    # engagement id
+    engagement = Column(String(64), nullable=True, default=None)
+
 
     def to_json(self, exclude_fields: tuple = ()) -> dict:
         json_dict = super().to_json(exclude_fields=("requests",))

--- a/models/api_tests.py
+++ b/models/api_tests.py
@@ -165,8 +165,6 @@ class PerformanceApiTest(db_tools.AbstractBaseMixin, db.Base, rpc_tools.RpcMixin
             for integration_name, integration_data in integration.items():
                 try:
                     # we never commit, so this is fine
-                    log.info(f'integration_name:{integration_name}')
-                    log.info(f'data:{integration_data}')
                     integration[integration_name] = self.rpc.call_function_with_timeout(
                         func=f'backend_performance_execution_json_config_{integration_name}',
                         timeout=3,

--- a/models/api_tests.py
+++ b/models/api_tests.py
@@ -160,12 +160,13 @@ class PerformanceApiTest(db_tools.AbstractBaseMixin, db.Base, rpc_tools.RpcMixin
 
     def configure_execution_json(self, execution: bool = False) -> dict:
         exec_params = ExecutionParams.from_orm(self).dict(exclude_none=True)
-
         mark_for_delete = defaultdict(list)
         for section, integration in self.integrations.items():
             for integration_name, integration_data in integration.items():
                 try:
                     # we never commit, so this is fine
+                    log.info(f'integration_name:{integration_name}')
+                    log.info(f'data:{integration_data}')
                     integration[integration_name] = self.rpc.call_function_with_timeout(
                         func=f'backend_performance_execution_json_config_{integration_name}',
                         timeout=3,

--- a/slots/backend_performance.py
+++ b/slots/backend_performance.py
@@ -9,7 +9,10 @@ class Slot:  # pylint: disable=E1101,R0903
     def content(self, context, slot, payload):
         project_id = context.rpc_manager.call.project_get_id()
         public_regions = context.rpc_manager.call.get_rabbit_queues("carrier")
-        public_regions.remove("__internal")
+        try:
+            public_regions.remove("__internal")
+        except:
+            pass
         project_regions = context.rpc_manager.call.get_rabbit_queues(f"project_{project_id}_vhost")
         cloud_regions = context.rpc_manager.call.integrations_get_cloud_integrations(
                 project_id)

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -83,7 +83,7 @@ def _calculate_limit(limit, total):
     return len(total) if limit == 'All' else limit
 
 
-def run_test(test: 'PerformanceApiTest', config_only: bool = False, execution: bool = False
+def run_test(test: 'PerformanceApiTest', config_only: bool = False, execution: bool = False, engagement_id: str = None
 ) -> dict:
     event = test.configure_execution_json(
         execution=execution
@@ -114,7 +114,8 @@ def run_test(test: 'PerformanceApiTest', config_only: bool = False, execution: b
         onexx=0, twoxx=0, threexx=0, fourxx=0, fivexx=0,
         requests="",
         test_uid=test.test_uid,
-        test_config=test.api_json()
+        test_config=test.api_json(),
+        engagement=engagement_id
     )
     report.insert()
     event["cc_env_vars"]["REPORT_ID"] = str(report.id)


### PR DESCRIPTION
Changes:

1. Engagement field is added to the test report model
2. Api endpoints that start tests changed in the way that they are accepting engagement_id now
3. run_tests methods changed to include engagement_id value into report table 