### PR TITLE
fix(BE-PERFORMANCE) fixed chart;

### DIFF
--- a/static/js/htmlPlugin.js
+++ b/static/js/htmlPlugin.js
@@ -48,7 +48,7 @@ const htmlLegendPlugin = {
 
             const span = document.createElement('span');
             span.classList.add('legend-span');
-            span.style.width = '200px';
+            span.style.width = '120px';
 
             const text = document.createTextNode(item.text);
             span.appendChild(text);

--- a/static/js/performanceBackend.js
+++ b/static/js/performanceBackend.js
@@ -2,13 +2,9 @@ window.analyticsLine = undefined
 
 function displayAnalytics() {
     $("#preset").hide();
-    analyticsCanvas();
     $("#analytics").show();
     $("#chartjs-custom-legend-analytic").show();
-    if (!$("#analytics").is(":visible")) {
-        console.log("Here")
-    }
-
+    vueVm.registered_components.analyticFilter.reDrawChart();
 }
 
 function getData(scope, request_name) {
@@ -45,11 +41,11 @@ function turnOnAllLine() {
     window.analyticsLine.data.datasets.forEach((item, index) => {
         window.analyticsLine.setDatasetVisibility(index, true)
     })
-    window.analyticsLine.update();
+    // window.analyticsLine.update();
 }
 
 function analyticsCanvas(data) {
-    window.analyticsLine !== undefined && window.analyticsLine.destroy()
+    console.log(data)
     window.analyticsLine = new Chart('chart-analytics', {
         type: 'line',
         data: data,
@@ -77,7 +73,7 @@ function analyticsCanvas(data) {
                     position: 'right',
                     beginAtZero: true,
                     grid: {
-                        drawOnChartArea: false, // only want the grid lines for one axis to show up
+                        drawOnChartArea: false,
                     },
                 },
             },
@@ -135,4 +131,6 @@ function clearAnalyticChart() {
     analyticsLine.data.datasets = [];
     analyticsLine.update();
     document.getElementById('chartjs-custom-legend-analytic').innerHTML = '';
+    $('#chart-analytics').hide();
+    $('#layout_empty-chart').show();
 }

--- a/static/js/responses_chart.js
+++ b/static/js/responses_chart.js
@@ -5,10 +5,6 @@ const get_responses_chart = (mount_id, y_label, chartData) => {
         options: {
             animation: false,
             responsive: true,
-            // hoverMode: 'index',
-            // interaction: {
-            //     mode: 'point'
-            // },
             plugins: {
                 legend: {
                     display: false
@@ -17,88 +13,40 @@ const get_responses_chart = (mount_id, y_label, chartData) => {
                     display: false
                 }
             },
-            // title: {
-            //     display: false,
-            // },
-            // scales: {
-            //     xAxes: [
-            //         {
-            //             gridLines: {
-            //                 display: false
-            //             }
-            //         }
-            //     ],
-            //     yAxes: [
-            //         {
-            //             type: "linear", // only linear but allow scale type registration. This allows extensions to exist solely for log scale for instance
-            //             display: true,
-            //             position: "left",
-            //             scaleLabel: {
-            //                 display: true,
-            //                 labelString: y_label
-            //             },
-            //             id: "response_time",
-            //             gridLines: {
-            //                 borderDash: [2, 1],
-            //                 color: "#D3D3D3"
-            //             },
-            //             ticks: {
-            //                 beginAtZero: true,
-            //                 maxTicksLimit: 10
-            //             },
-            //         },
-            //         {
-            //             type: "linear", // only linear but allow scale type registration. This allows extensions to exist solely for log scale for instance
-            //             display: true,
-            //             position: "right",
-            //             gridLines: {
-            //                 display: false
-            //             },
-            //             ticks: {
-            //                 beginAtZero: true,
-            //                 maxTicksLimit: 10
-            //             },
-            //             // id: "active_users",
-            //         }
-            //     ],
-            // }
             scales: {
                 x: {
                     type: 'time',
                     grid: {
-                        display: false
+                        display: false,
+                        drawOnChartArea: false,
                     }
                 },
                 response_time: {
                     type: 'linear',
                     position: 'left',
+                    beginAtZero: true,
                     text: y_label,
                     display: true,
                     grid: {
                         display: true,
+                        drawOnChartArea: true,
                         borderDash: [2, 1],
                         color: "#D3D3D3"
                     },
-                    ticks: {
-                        count: 10
-                    }
                 },
                 active_users: {
                     type: 'linear',
                     position: 'right',
+                    beginAtZero: true,
                     min: 0,
                     grid: {
-                        display: false,
-                        drawOnChartArea: false,
+                        display: true,
+                        drawOnChartArea: true,
                     },
-                    // ticks: {
-                    //     count: 10
-                    // }
                 }
             }
         },
         plugins: []
     }
-    // const presetsContext = document.getElementById("chart-requests").getContext("2d");
     return new Chart(mount_id, chart_options);
 }

--- a/static/js/results.js
+++ b/static/js/results.js
@@ -164,12 +164,13 @@ const SummaryController = {
         },
         async handle_slider_change(values) {
             [this.slider.low, this.slider.high] = values
-            await this.handle_tab_load(this.active_tab_id)
             if (this.active_tab_id === 'AN') {
                 vueVm.registered_components.analyticFilter.recalculateChartBySlider();
+            } else {
+                await this.handle_tab_load(this.active_tab_id);
+                this.fill_error_table()
+                await window.engine_health?.reload()
             }
-            this.fill_error_table()
-            await window.engine_health?.reload()
         },
         handle_tab_change(event) {
             this.active_tab_id = event.target.id
@@ -250,9 +251,6 @@ const SummaryController = {
                     analyticsLine.destroy();
                 }
             }
-            // if ($("#end_time").html() != "") {
-            //     $("#PP").hide();
-            // }
             const resp = await fetch(url + '?' + new URLSearchParams({
                 build_id: this.build_id,
                 test_name: this.test_name,
@@ -274,16 +272,8 @@ const SummaryController = {
                     window.presetLine.data = data
                     window.presetLine.update()
                 }
-                // if (window.presetLine != null) {
-                //     // window.presetLine.destroy();
-                // } else {
-                //     //
-                // }
-                // drawCanvas(y_label, data);
 
                 $('#chart-loader').hide();
-                // document.getElementById('chartjs-custom-legend').innerHTML = window.presetLine.generateLegend();
-                // document.getElementById('chartjs-custom-legend').innerHTML = Chart.defaults.plugins.legend.labels.generateLabels(window.presetLine)
             } else {
                 // todo: handle fetch error
             }

--- a/templates/results/summary.html
+++ b/templates/results/summary.html
@@ -23,7 +23,7 @@
 {#        <br/>#}
 
         <div class="card card-12 p-28 mt-3" id="under-summary-controller">
-            <div class="d-flex justify-content-between pb-4">
+            <div class="d-flex justify-content-between pb-3">
                 <div class="d-flex align-items-center">
                     <p class="font-h3 font-bold mr-4">Requests summary</p>
                     {% if test_data['test_status']['status'].lower() not in ['finished', 'error', 'failed', 'success'] %}
@@ -149,6 +149,14 @@
                                  class="layout-spinner">
                                 <i class="spinner-loader__32x32 spinner-centered"></i>
                             </div>
+                            <div id="layout_empty-chart" style="background: #FAFBFD;" class="h-100 rounded-lg">
+                                <div class="d-flex justify-content-center align-items-center h-100">
+                                    <div class="d-flex flex-column align-items-center">
+                                        <p class="font-h5 text-gray-500 pb-2">Select request and metrics to build graph analytics</p>
+                                        <img src="/design-system/static/assets/ico/icon_empty-chart.svg">
+                                    </div>
+                                </div>
+                            </div>
                             <canvas id="chart-analytics" height="100%"></canvas>
                         </div>
                         <analytic-filter
@@ -159,19 +167,19 @@
                         </analytic-filter>
                     </div>
                 </div>
-                <div class="row pl-2 mt-4 w-100">
+                <div class="row pl-2 mt-4" style="width: calc(100% - 290px);">
                     <div class="col">
                         <label class="w-100 mb-0 font-h5 font-semibold">
                             Time picker
                         </label>
-                        <div style="width: calc(100% - 290px);">
+                        <div>
                             <div class="slider-holder">
                                 <div id="vuh-performance-time-picker"></div>
                             </div>
                         </div>
                     </div>
                 </div>
-                <div id="chartjs-custom-legend-analytic" style="width: calc(100% - 290px);">
+                <div id="chartjs-custom-legend-analytic">
                 </div>
             </div>
         </div>


### PR DESCRIPTION
- Show only one Axis (time or count) if other is absent;
- Added "Empty Layout" if filter is empty;
- Fix bug when user removes filter's block with metrics which wasn't draw on the chart.
- show chart with filters setting, after changing tabs;

<img width="1510" alt="Screenshot 2023-03-03 at 22 20 43" src="https://user-images.githubusercontent.com/46873056/222821971-9f71ed25-7284-4ef4-aa1f-06ece1c8b2e0.png">
<img width="1512" alt="Screenshot 2023-03-03 at 22 24 18" src="https://user-images.githubusercontent.com/46873056/222821988-681a3477-d376-4041-b7ba-6982a8b3aa4d.png">
